### PR TITLE
refactor: use delete instead of flagDelete

### DIFF
--- a/src/bot/mgp/deleteRedirect.ts
+++ b/src/bot/mgp/deleteRedirect.ts
@@ -48,7 +48,7 @@ const recordInUsed = async (inUsed: string[]) => {
     );
 };
 
-const processRecent = async (lgusername: string) => {
+const processRecent = async () => {
     const filepath = 'data/inUsedRedirect.json',
         { content, sha } = await readGHFile(filepath),
         record = JSON.parse(content) as Record<string, string[]>,
@@ -64,13 +64,18 @@ const processRecent = async (lgusername: string) => {
         const { isFalse: notInUsed, isTrue: inUsed } = booleanFilter(usage);
 
         if (notInUsed.length > 0) {
-            await cmbot.flagDelete(
-                notInUsed,
-                '移动残留重定向',
-                lgusername,
-                '自动挂删文件移动残留重定向',
+            await Promise.all(
+                notInUsed.map(async title => {
+                    await cmapi.postWithToken('csrf', {
+                        action: 'delete',
+                        title,
+                        reason: '自动删除文件移动残留重定向',
+                        tags: 'Bot',
+                        bot: true,
+                    });
+                }),
             );
-            console.log(`挂删记录中的 ${notInUsed.length} 个新无使用重定向`);
+            console.log(`删除记录中的 ${notInUsed.length} 个新无使用重定向`);
         }
 
         if (inUsed.length > 0) {
@@ -94,7 +99,7 @@ const processRecent = async (lgusername: string) => {
     console.log(`Start time: ${new Date().toISOString()}`);
 
     await new Login(zhapi).login({ site: 'zh', account: 'bot' });
-    const { lgusername } = await new Login(cmapi).login({ site: 'cm', account: 'bot' });
+    await new Login(cmapi).login({ site: 'cm', account: 'bot' });
 
     const movedFiles = await getRecentMoves();
 
@@ -109,21 +114,23 @@ const processRecent = async (lgusername: string) => {
         await recordInUsed(isTrue);
     }
 
-    const success = await cmbot.flagDelete(
-        isFalse,
-        '移动残留重定向',
-        lgusername,
-        '自动挂删文件移动残留重定向',
-    );
-
-    if (success.length > 0) {
-        console.log(`成功挂删 ${success.length} 个重定向：\n${success.join('\n')}`);
+    if (isFalse.length > 0) {
+        await Promise.all(
+            isFalse.map(async title => {
+                await cmapi.postWithToken('csrf', {
+                    action: 'delete',
+                    title,
+                    reason: '自动删除文件移动残留重定向',
+                    tags: 'Bot',
+                    bot: true,
+                });
+            }),
+        );
     } else {
-        console.log('没有需要挂删的重定向');
+        console.log('没有需要删除的重定向');
     }
 
-    console.log('执行记录挂删。');
-    await processRecent(lgusername);
+    await processRecent();
 
     await updateTimeData('deleteRedirect', lestart);
 

--- a/src/bot/mgp/deleteUnused.ts
+++ b/src/bot/mgp/deleteUnused.ts
@@ -10,7 +10,7 @@ interface Config {
     console.log(`Start time: ${new Date().toISOString()}`);
 
     await new Login(zhapi).login({ site: 'zh', account: 'bot' });
-    const { lgusername } = await new Login(cmapi).login({ site: 'cm', account: 'bot' });
+    await new Login(cmapi).login({ site: 'cm', account: 'bot' });
 
     const zhbot = new BotInstance(zhapi),
         cmbot = new BotInstance(cmapi);
@@ -25,7 +25,17 @@ interface Config {
     const { isFalse } = booleanFilter(await cmbot.checkGlobalUsage(files)),
         needDel = isFalse.filter(item => !unlink.includes(item));
 
-    await cmbot.flagDelete(needDel, '无使用或不再使用的文件', lgusername);
+    await Promise.all(
+        needDel.map(async title => {
+            await cmapi.postWithToken('csrf', {
+                action: 'delete',
+                title,
+                reason: '无使用或不再使用的文件',
+                tags: 'Bot',
+                bot: true,
+            });
+        }),
+    );
 
     console.log(needDel.length > 0 ? 'All unused deleted.' : 'No file need to delete.');
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -11,16 +11,16 @@ import { GetLinked } from './getLinked';
 import { QueryCategory } from './queryCategory';
 
 class BotInstance {
-    batchQuery: BatchQuery['query'];
-    checkExist: CheckExist['check'];
-    checkGlobalUsage: CheckGlobalUsage['check'];
-    checkRedirect: CheckRedirect['check'];
-    flagDelete: FlagDelete['del'];
-    getContent: GetContent['get'];
-    getEmbedded: GetEmbedded['get'];
-    getJson: GetJSON['get'];
-    getLinked: GetLinked['get'];
-    queryCategory: QueryCategory['query'];
+    batchQuery;
+    checkExist;
+    checkGlobalUsage;
+    checkRedirect;
+    flagDelete;
+    getContent;
+    getEmbedded;
+    getJson;
+    getLinked;
+    queryCategory;
 
     constructor(api: MediaWikiApi) {
         this.batchQuery = new BatchQuery(api).query;


### PR DESCRIPTION
## Summary by Sourcery

将当前标记删除的工作流替换为在 cm wiki 上对未使用和残留的重定向文件直接执行删除操作。

Bug Fixes（错误修复）:
- 删除操作时，不再依赖 cm 登录中的已登录用户名。

Enhancements（增强改进）:
- 优化删除日志和消息，使其反映为直接删除而不是标记删除。
- 放宽 `BotInstance` 属性的类型定义，避免与特定方法签名的强耦合。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace flagged deletion workflow with direct delete actions for unused and leftover redirect files on the cm wiki.

Bug Fixes:
- Stop relying on the logged-in username from the cm login when performing deletion operations.

Enhancements:
- Refine deletion logs and messages to reflect direct deletions instead of flagging for deletion.
- Relax BotInstance property typings to avoid tight coupling to specific method signatures.

</details>